### PR TITLE
Fix import batches for invalid initialize case

### DIFF
--- a/app/batches/import_data_source_definitions.rb
+++ b/app/batches/import_data_source_definitions.rb
@@ -12,7 +12,7 @@ class ImportDataSourceDefinitions
     all_table_memos.each {|memo| memo.linked = false }
 
     data_source_tables.group_by(&:schema_name).each do |schema_name, source_tables|
-      schema_memo = schema_memos.find_or_create_by(name: schema_name)
+      schema_memo = schema_memos.find_or_create_by!(name: schema_name)
       schema_memo.update!(linked: true)
       begin
         ImportSchemaDefinitions.import_table_memos!(source_tables, schema_memo.table_memos)

--- a/app/batches/import_data_source_raw_datasets.rb
+++ b/app/batches/import_data_source_raw_datasets.rb
@@ -12,11 +12,11 @@ class ImportDataSourceRawDatasets
     data_source_tables = data_source.data_source_tables
 
     data_source_tables.group_by(&:schema_name).each do |schema_name, source_tables|
-      schema_memo = db_memo.schema_memos.find_or_create_by(name: schema_name)
+      schema_memo = db_memo.schema_memos.find_or_create_by!(name: schema_name)
       table_memos = schema_memo.table_memos
 
       source_tables.each do |source_table|
-        table_memo = schema_memo.table_memos.find_or_create_by(name: source_table.table_name)
+        table_memo = schema_memo.table_memos.find_or_create_by!(name: source_table.table_name)
         begin
           ImportTableRawDatasets.import_table_memo_raw_dataset!(table_memo, source_table)
         rescue DataSource::ConnectionBad => e

--- a/app/batches/import_schema_definitions.rb
+++ b/app/batches/import_schema_definitions.rb
@@ -4,7 +4,7 @@ class ImportSchemaDefinitions
     data_source = DataSource.find_by(name: data_source_name)
     source_tables = data_source.data_source_tables.select {|table| table.schema_name == schema_name }
 
-    schema_memo = data_source.database_memo.schema_memos.find_or_create_by(name: schema_name)
+    schema_memo = data_source.database_memo.schema_memos.find_or_create_by!(name: schema_name)
     table_memos = schema_memo.table_memos
     table_memos.each {|memo| memo.linked = false }
 
@@ -21,7 +21,7 @@ class ImportSchemaDefinitions
 
   def self.import_table_memos!(source_tables, table_memos)
     source_tables.each do |source_table|
-      table_memo = table_memos.find_or_create_by(name: source_table.table_name)
+      table_memo = table_memos.find_or_create_by!(name: source_table.table_name)
       table_memo.update!(linked: true)
       begin
         ImportTableDefinitions.import_column_memos!(source_table, table_memo)

--- a/app/batches/import_schema_raw_datasets.rb
+++ b/app/batches/import_schema_raw_datasets.rb
@@ -4,10 +4,10 @@ class ImportSchemaRawDatasets
     data_source = DataSource.find_by(name: data_source_name)
     source_tables = data_source.data_source_tables.select {|dst| dst.schema_name == schema_name }
 
-    schema_memo = data_source.database_memo.schema_memos.find_or_create_by(name: schema_name)
+    schema_memo = data_source.database_memo.schema_memos.find_or_create_by!(name: schema_name)
 
     source_tables.each do |source_table|
-      table_memo = schema_memo.table_memos.find_or_create_by(name: source_table.table_name)
+      table_memo = schema_memo.table_memos.find_or_create_by!(name: source_table.table_name)
       begin
         ImportTableRawDatasets.import_table_memo_raw_dataset!(table_memo, source_table)
       rescue DataSource::ConnectionBad => e

--- a/app/batches/import_table_definitions.rb
+++ b/app/batches/import_table_definitions.rb
@@ -1,11 +1,11 @@
 class ImportTableDefinitions
 
-  def self.run(database_name, schema_name, table_name)
+  def self.run(data_source_name, schema_name, table_name)
     data_source = DataSource.find_by(name: data_source_name)
     source_table = data_source.data_source_tables.find {|dst| dst.full_table_name == "#{schema_name}.#{table_name}" }
 
     schema_memo = data_source.database_memo.schema_memos.find_by(name: schema_name)
-    table_memo = schema_memo.table_memos.find_or_create_by(name: table_name)
+    table_memo = schema_memo.table_memos.find_or_create_by!(name: table_name)
 
     if source_table.nil?
       table_memo.linked = false

--- a/app/batches/import_table_raw_datasets.rb
+++ b/app/batches/import_table_raw_datasets.rb
@@ -6,7 +6,7 @@ class ImportTableRawDatasets
     source_table = data_source.data_source_tables.find {|dst| dst.full_table_name == "#{schema_name}.#{table_name}" }
 
     schema_memo = data_source.database_memo.schema_memos.find_by(name: schema_name)
-    table_memo = schema_memo.table_memos.find_or_create_by(name: table_name)
+    table_memo = schema_memo.table_memos.find_or_create_by!(name: table_name)
 
     begin
       import_table_memo_raw_dataset!(table_memo, source_table)


### PR DESCRIPTION
`find_or_create_by` will return an initialized object even if the input is invalid
https://api.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-find_or_create_by

Change to `find_or_create_by!` to stop the batch with an error if the input is invalid.
https://api.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-find_or_create_by-21