### PR TITLE
Modify import batch to obsolate a dependency on search_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 - Modify listed item UI [#263](https://github.com/hogelog/dmemo/pull/263)
 - Improve visibility in browser tab [#262](https://github.com/hogelog/dmemo/pull/262)
 - Modify search result page [#268](https://github.com/hogelog/dmemo/pull/268)
+- Fix a type of image_url column in User table [#271](https://github.com/hogelog/dmemo/pull/271)
+- Add batch to split synchronize process [#274](https://github.com/teamdmemo/dmemo/pull/274)
+- Modify config for development environment [#280](https://github.com/teamdmemo/dmemo/pull/280)
+- Modify import batch to obsolate a dependency on search_path [#282](https://github.com/teamdmemo/dmemo/pull/282)
 
 ## 0.8.1
 - Upgrade gems not versioned in Gemfile [#252](https://github.com/hogelog/dmemo/pull/252)

--- a/app/batches/README.md
+++ b/app/batches/README.md
@@ -1,0 +1,34 @@
+# batche
+
+For synchronization of database information from data source.  
+The behavior differs greatly depending on whether you use SynchronizeDataSources or not.  
+All batches except SynchronizeDataSources are new beta batches added to improve batch operations.
+
+## SynchronizeDataSources
+
+Synchronize all data from all data sources.  
+IgnoredTables and MskedData will work. 
+If the number of schemas and tables to be synchronized is large, it will take a long time to synchronize.  
+Until v0.8.1, the target schema was dependent on the search_path in PostgreSQL and Redshift. Starting from the next version, search_path will no longer be used. Synchronize all visible schemas by a user account of Dmemo access.
+
+
+## Import Batches
+
+This is a new batch that replaces SynchronizeDataSources. New batches have been created to reduce the time spent on fetching and to make it easier to manage the schemas to be fetched.  
+**This is a beta version and is currently in trial.**  
+IgnoredTables and MskedData work. Only schemas that have SchemaMemo and are linked in Dmemo will be imported.  
+If you don't want to include them, the Dmemo administrator can edit the DataSource and unlink it.  
+Since we have created batches for each granularity, we need to specify the target with an argument for each granularity.  
+
+### For Sample
+```
+$bundle exec rails runner 'ImportDataSourceDefinitions.run("DWH”)’
+
+$bundle exec rails runner 'ImportSchemaRawDatasets.run("DWH", “sample_schema”)’
+
+$bundle exec rails runner 'ImportTableDefinitions.run("DWH", “sample_schema", “target_table”)'
+```
+
+## SynchronizeDefinitions / SynchronizeRawDatasets
+
+Run `ImportDataSourceDefinitions` / `ImportDataSourceRawDatasets` for all data sources.

--- a/app/batches/README.md
+++ b/app/batches/README.md
@@ -1,4 +1,4 @@
-# batche
+# Batch Jobs
 
 For synchronization of database information from data source.  
 The behavior differs greatly depending on whether you use SynchronizeDataSources or not.  
@@ -20,7 +20,7 @@ IgnoredTables and MskedData work. Only schemas that have SchemaMemo and are link
 If you don't want to include them, the Dmemo administrator can edit the DataSource and unlink it.  
 Since we have created batches for each granularity, we need to specify the target with an argument for each granularity.  
 
-### For Sample
+### For Examples
 ```
 $bundle exec rails runner 'ImportDataSourceDefinitions.run("DWH”)’
 

--- a/app/batches/import_data_source_definitions.rb
+++ b/app/batches/import_data_source_definitions.rb
@@ -6,15 +6,17 @@ class ImportDataSourceDefinitions
 
     db_memo = DatabaseMemo.find_or_create_by!(name: data_source.name)
     schema_memos = db_memo.schema_memos
+    linked_schema_names = schema_memos.where(linked: true).pluck(:name)
     schema_memos.each {|memo| memo.linked = false }
 
     all_table_memos = schema_memos.map(&:table_memos).map(&:to_a).flatten
     all_table_memos.each {|memo| memo.linked = false }
 
     data_source_tables.group_by(&:schema_name).each do |schema_name, source_tables|
-      schema_memo = schema_memos.find_by!(name: schema_name)
-      next if schema_mnemo.nil?
-      schema_memo.update!(linked: true)
+      next unless linked_schema_names.include?(schema_name)
+      schema_memo = schema_memos.find {|memo| memo.name == schema_name }
+      next if schema_memo.nil?
+      schema_memo.linked = true
       begin
         ImportSchemaDefinitions.import_table_memos!(source_tables, schema_memo.table_memos)
       rescue DataSource::ConnectionBad => e

--- a/app/batches/import_data_source_definitions.rb
+++ b/app/batches/import_data_source_definitions.rb
@@ -12,7 +12,8 @@ class ImportDataSourceDefinitions
     all_table_memos.each {|memo| memo.linked = false }
 
     data_source_tables.group_by(&:schema_name).each do |schema_name, source_tables|
-      schema_memo = schema_memos.find_or_create_by!(name: schema_name)
+      schema_memo = schema_memos.find_by!(name: schema_name)
+      next if schema_mnemo.nil?
       schema_memo.update!(linked: true)
       begin
         ImportSchemaDefinitions.import_table_memos!(source_tables, schema_memo.table_memos)

--- a/app/batches/import_data_source_raw_datasets.rb
+++ b/app/batches/import_data_source_raw_datasets.rb
@@ -12,7 +12,8 @@ class ImportDataSourceRawDatasets
     data_source_tables = data_source.data_source_tables
 
     data_source_tables.group_by(&:schema_name).each do |schema_name, source_tables|
-      schema_memo = db_memo.schema_memos.find_or_create_by!(name: schema_name)
+      schema_memo = db_memo.schema_memos.find_by(name: schema_name)
+      next if schema_mnemo.nil?
       table_memos = schema_memo.table_memos
 
       source_tables.each do |source_table|

--- a/app/batches/import_data_source_raw_datasets.rb
+++ b/app/batches/import_data_source_raw_datasets.rb
@@ -12,8 +12,8 @@ class ImportDataSourceRawDatasets
     data_source_tables = data_source.data_source_tables
 
     data_source_tables.group_by(&:schema_name).each do |schema_name, source_tables|
-      schema_memo = db_memo.schema_memos.find_by(name: schema_name)
-      next if schema_mnemo.nil?
+      schema_memo = db_memo.schema_memos.find_by(name: schema_name, linked: true)
+      next if schema_memo.nil?
       table_memos = schema_memo.table_memos
 
       source_tables.each do |source_table|

--- a/app/batches/import_schema_definitions.rb
+++ b/app/batches/import_schema_definitions.rb
@@ -4,14 +4,13 @@ class ImportSchemaDefinitions
     data_source = DataSource.find_by(name: data_source_name)
     source_tables = data_source.data_source_tables.select {|table| table.schema_name == schema_name }
 
-    schema_memo = data_source.database_memo.schema_memos.find_by!(name: schema_name)
+    schema_memo = data_source.database_memo.schema_memos.find_by!(name: schema_name, linked: true)
     table_memos = schema_memo.table_memos
     table_memos.each {|memo| memo.linked = false }
 
     if source_tables.empty?
       schema_memo.linked = false
     else
-      schema_memo.linked = true
       self.import_table_memos!(source_tables, table_memos)
     end
 

--- a/app/batches/import_schema_definitions.rb
+++ b/app/batches/import_schema_definitions.rb
@@ -4,7 +4,7 @@ class ImportSchemaDefinitions
     data_source = DataSource.find_by(name: data_source_name)
     source_tables = data_source.data_source_tables.select {|table| table.schema_name == schema_name }
 
-    schema_memo = data_source.database_memo.schema_memos.find_or_create_by!(name: schema_name)
+    schema_memo = data_source.database_memo.schema_memos.find_by!(name: schema_name)
     table_memos = schema_memo.table_memos
     table_memos.each {|memo| memo.linked = false }
 

--- a/app/batches/import_schema_raw_datasets.rb
+++ b/app/batches/import_schema_raw_datasets.rb
@@ -4,7 +4,7 @@ class ImportSchemaRawDatasets
     data_source = DataSource.find_by(name: data_source_name)
     source_tables = data_source.data_source_tables.select {|dst| dst.schema_name == schema_name }
 
-    schema_memo = data_source.database_memo.schema_memos.find_or_create_by!(name: schema_name)
+    schema_memo = data_source.database_memo.schema_memos.find_by!(name: schema_name)
 
     source_tables.each do |source_table|
       table_memo = schema_memo.table_memos.find_or_create_by!(name: source_table.table_name)

--- a/app/batches/import_schema_raw_datasets.rb
+++ b/app/batches/import_schema_raw_datasets.rb
@@ -4,7 +4,7 @@ class ImportSchemaRawDatasets
     data_source = DataSource.find_by(name: data_source_name)
     source_tables = data_source.data_source_tables.select {|dst| dst.schema_name == schema_name }
 
-    schema_memo = data_source.database_memo.schema_memos.find_by!(name: schema_name)
+    schema_memo = data_source.database_memo.schema_memos.find_by!(name: schema_name, linked: true)
 
     source_tables.each do |source_table|
       table_memo = schema_memo.table_memos.find_or_create_by!(name: source_table.table_name)

--- a/app/batches/import_table_definitions.rb
+++ b/app/batches/import_table_definitions.rb
@@ -4,7 +4,7 @@ class ImportTableDefinitions
     data_source = DataSource.find_by(name: data_source_name)
     source_table = data_source.data_source_tables.find {|dst| dst.full_table_name == "#{schema_name}.#{table_name}" }
 
-    schema_memo = data_source.database_memo.schema_memos.find_by(name: schema_name)
+    schema_memo = data_source.database_memo.schema_memos.find_by!(name: schema_name)
     table_memo = schema_memo.table_memos.find_or_create_by!(name: table_name)
 
     if source_table.nil?

--- a/app/batches/import_table_definitions.rb
+++ b/app/batches/import_table_definitions.rb
@@ -4,7 +4,7 @@ class ImportTableDefinitions
     data_source = DataSource.find_by(name: data_source_name)
     source_table = data_source.data_source_tables.find {|dst| dst.full_table_name == "#{schema_name}.#{table_name}" }
 
-    schema_memo = data_source.database_memo.schema_memos.find_by!(name: schema_name)
+    schema_memo = data_source.database_memo.schema_memos.find_by!(name: schema_name, linked: true)
     table_memo = schema_memo.table_memos.find_or_create_by!(name: table_name)
 
     if source_table.nil?
@@ -18,7 +18,7 @@ class ImportTableDefinitions
         Rails.logger.error e
       end
     end
-    table_memo.save! if table_memo.changed?
+    table_memo.save! if table_memo.has_changes_to_save?
   end
 
   def self.import_column_memos!(source_table, table_memo)
@@ -32,7 +32,7 @@ class ImportTableDefinitions
       column_memo = column_memos.find {|memo| memo.name == column.name } || table_memo.column_memos.build(name: column.name)
       column_memo.linked = true
       column_memo.assign_attributes(sql_type: column.sql_type, default: column.default, nullable: column.null, position: position)
-      column_memo.save! if column_memo.changed?
+      column_memo.save! if column_memo.has_changes_to_save?
     end
   end
 end

--- a/app/batches/import_table_raw_datasets.rb
+++ b/app/batches/import_table_raw_datasets.rb
@@ -5,7 +5,7 @@ class ImportTableRawDatasets
     data_source = DataSource.find_by(name: data_source_name)
     source_table = data_source.data_source_tables.find {|dst| dst.full_table_name == "#{schema_name}.#{table_name}" }
 
-    schema_memo = data_source.database_memo.schema_memos.find_by(name: schema_name)
+    schema_memo = data_source.database_memo.schema_memos.find_by!(name: schema_name)
     table_memo = schema_memo.table_memos.find_or_create_by!(name: table_name)
 
     begin

--- a/app/batches/import_table_raw_datasets.rb
+++ b/app/batches/import_table_raw_datasets.rb
@@ -5,7 +5,7 @@ class ImportTableRawDatasets
     data_source = DataSource.find_by(name: data_source_name)
     source_table = data_source.data_source_tables.find {|dst| dst.full_table_name == "#{schema_name}.#{table_name}" }
 
-    schema_memo = data_source.database_memo.schema_memos.find_by!(name: schema_name)
+    schema_memo = data_source.database_memo.schema_memos.find_by!(name: schema_name, linked: true)
     table_memo = schema_memo.table_memos.find_or_create_by!(name: table_name)
 
     begin

--- a/app/controllers/data_sources_controller.rb
+++ b/app/controllers/data_sources_controller.rb
@@ -42,8 +42,9 @@ class DataSourcesController < ApplicationController
     rescue NotImplementedError => e
       # when not implement fetch_schema_names for adapter
       # data_sources/:id/edit page does not view Schema Candidates block
-    rescue ActiveRecord::ActiveRecordError, Mysql2::Error, PG::Error => e
-      raise DataSource::ConnectionBad.new(e)
+    rescue ActiveRecord::ActiveRecordError, DataSource::ConnectionBad => e
+      flash[:error] = e.message
+      redirect_to edit_data_source_path(id)
     end
 
     @data_source.password = DUMMY_PASSWORD

--- a/app/controllers/data_sources_controller.rb
+++ b/app/controllers/data_sources_controller.rb
@@ -44,7 +44,7 @@ class DataSourcesController < ApplicationController
       # data_sources/:id/edit page does not view Schema Candidates block
     rescue ActiveRecord::ActiveRecordError, DataSource::ConnectionBad => e
       flash[:error] = e.message
-      redirect_to edit_data_source_path(id)
+      redirect_to data_sources_path
     end
 
     @data_source.password = DUMMY_PASSWORD

--- a/app/helpers/data_source_helper.rb
+++ b/app/helpers/data_source_helper.rb
@@ -4,7 +4,7 @@ module DataSourceHelper
   end
 
   def exist?(schema_name)
-    @redshift_schema_names.include?(schema_name)
+    @data_source_schema_names.include?(schema_name)
   end
 
   def able_to_import?(schema_name)

--- a/app/helpers/data_source_helper.rb
+++ b/app/helpers/data_source_helper.rb
@@ -1,0 +1,25 @@
+module DataSourceHelper
+  def subscribe?(schema_name)
+    @subscribe_schema_names.include?(schema_name)
+  end
+
+  def exist?(schema_name)
+    @redshift_schema_names.include?(schema_name)
+  end
+
+  def able_to_import?(schema_name)
+    !subscribe?(schema_name) && exist?(schema_name)
+  end
+
+  def able_to_unlink?(schema_name)
+    subscribe?(schema_name)
+  end
+
+  def disable_import_button(schema_name)
+    able_to_import?(schema_name) ? "" : "disabled"
+  end
+
+  def disable_unlink_button(schema_name)
+    able_to_unlink?(schema_name) ? "" : "disabled"
+  end
+end

--- a/app/models/data_source_adapters/base.rb
+++ b/app/models/data_source_adapters/base.rb
@@ -4,6 +4,10 @@ module DataSourceAdapters
       @data_source = data_source
     end
 
+    def fetch_schema_names
+      raise NotImplementedError
+    end
+
     def fetch_table_names
       raise NotImplementedError
     end

--- a/app/models/data_source_adapters/mysql2_adapter.rb
+++ b/app/models/data_source_adapters/mysql2_adapter.rb
@@ -1,5 +1,9 @@
 module DataSourceAdapters
   class Mysql2Adapter < StandardAdapter
+    def fetch_schema_names
+      @schema_names ||= [[@data_source.dbname, 'unknown']]
+    end
+
     def fetch_table_names
       source_base_class.connection.tables.map { |table_name| [@data_source.dbname, table_name] }
     rescue ActiveRecord::ActiveRecordError, Mysql2::Error => e

--- a/app/models/data_source_adapters/postgresql_adapter.rb
+++ b/app/models/data_source_adapters/postgresql_adapter.rb
@@ -1,5 +1,13 @@
 module DataSourceAdapters
   class PostgresqlAdapter < StandardAdapter
+    def fetch_schema_names
+      @schema_names ||= source_base_class.connection.query(<<~SQL, 'SCHEMA')
+        SELECT nspname as schema_name, usename as owner_name
+        FROM pg_catalog.pg_namespace s join pg_catalog.pg_user u on u.usesysid = s.nspowner
+        ORDER BY schema_name;
+      SQL
+    end
+
     def fetch_table_names
       source_base_class.connection.query(<<~SQL, 'SCHEMA')
         SELECT schemaname, tablename

--- a/app/models/data_source_adapters/redshift_adapter.rb
+++ b/app/models/data_source_adapters/redshift_adapter.rb
@@ -51,7 +51,7 @@ module DataSourceAdapters
       connection.query(query, 'COLUMN').map do |name, sql_type, default, nullable, char_length|
         is_nullable =
           if spectrum?(table)
-            # could not get nullable info from Spectrum table
+            # FIXME: could not get nullable info from Spectrum table
             true
           else
             # is_nullable column in svv_columns contains 'YES' or 'NO' or null.

--- a/app/models/data_source_adapters/redshift_adapter.rb
+++ b/app/models/data_source_adapters/redshift_adapter.rb
@@ -4,7 +4,10 @@ module DataSourceAdapters
   class RedshiftAdapter < StandardAdapter
     def fetch_schema_names
       @schema_names ||= source_base_class.connection.query(<<~SQL, 'SCHEMA')
-        SELECT DISTINCT schema_name, schema_type, source_database FROM svv_all_schemas
+        SELECT nspname as schema_name, usename as owner_name
+        FROM pg_catalog.pg_namespace s join pg_catalog.pg_user u on u.usesysid = s.nspowner
+        WHERE usename != 'rdsdb'
+        ORDER BY schema_name;
       SQL
     end
 

--- a/app/models/data_source_adapters/standard_adapter.rb
+++ b/app/models/data_source_adapters/standard_adapter.rb
@@ -1,5 +1,9 @@
 module DataSourceAdapters
   class StandardAdapter < Base
+    def fetch_schema_names
+      raise NotImplementedError
+    end
+
     def fetch_table_names
       raise NotImplementedError
     end

--- a/app/views/data_sources/_form.html.haml
+++ b/app/views/data_sources/_form.html.haml
@@ -1,3 +1,5 @@
+.box-header.with-border
+  %h2.box-title Data Source Adapter Setting
 = form_for @data_source, html: { class: "form-horizontal" } do |f|
   .box-body
     .form-group

--- a/app/views/data_sources/_schema.html.haml
+++ b/app/views/data_sources/_schema.html.haml
@@ -8,25 +8,28 @@
     status schemas will be imported by batch. Click the Import button to add a schema to the whitelist.
   %p
     This schemas list is retrieved from
-    %code svv_all_schemas
+    - case @data_source.adapter
+      - when 'postgresql'
+        %code pg_catalog.pg_namespace
+      - when 'mysql2'
+        %code database_name
+      - when 'redshift'
+        %code pg_catalog.pg_namespace
     , so it has no effect on search_path or Ignored Tables on the setting page.
 
   %table.table.table-hover.table-bordered.table-striped{ role: "grid" }
     %tr
       %th schema name
-      %th schema type
-      %th souce database
+      %th schema owner
       %th{ width: "90px"} subscribe status
       %th{ width: "90px"} data source status
       %th{ width: "170px"}
-    - @all_schemas.each do |schema_name, schema_type, source_database|
+    - @all_schemas.each do |schema_name, schema_owner|
       %tr
         %td
           = schema_name
         %td
-          = schema_type
-        %td
-          = source_database
+          = schema_owner
         %td
           - if subscribe?(schema_name)
             %span.label.label-success Subscribe

--- a/app/views/data_sources/_schema.html.haml
+++ b/app/views/data_sources/_schema.html.haml
@@ -15,6 +15,8 @@
         %code database_name
       - when 'redshift'
         %code pg_catalog.pg_namespace
+      - else
+        %code (catalog table)
     , so it has no effect on search_path or Ignored Tables on the setting page.
 
   %table.table.table-hover.table-bordered.table-striped{ role: "grid" }

--- a/app/views/data_sources/_schema.html.haml
+++ b/app/views/data_sources/_schema.html.haml
@@ -1,0 +1,48 @@
+.box-header.with-border
+  %h2.box-title Schema Candidates
+
+.box-body
+  %p
+    Schema Candidates is a whitelist of schemas to be imported. Only
+    %span.label.label-success subscribe
+    status schemas will be imported by batch. Click the Import button to add a schema to the whitelist.
+  %p
+    This schemas list is retrieved from
+    %code svv_all_schemas
+    , so it has no effect on search_path or Ignored Tables on the setting page.
+
+  %table.table.table-hover.table-bordered.table-striped{ role: "grid" }
+    %tr
+      %th schema name
+      %th schema type
+      %th souce database
+      %th{ width: "90px"} subscribe status
+      %th{ width: "90px"} data source status
+      %th{ width: "170px"}
+    - @all_schemas.each do |schema_name, schema_type, source_database|
+      %tr
+        %td
+          = schema_name
+        %td
+          = schema_type
+        %td
+          = source_database
+        %td
+          - if subscribe?(schema_name)
+            %span.label.label-success Subscribe
+          - else
+            %span.label.label-danger Unsubscribe
+        %td
+          - if exist?(schema_name)
+            %span.label.label-success Exist
+          - else
+            %span.label.label-danger Disappeared
+        %td
+          = link_to import_schema_path(@data_source.id, schema_name), method: :patch,
+              class: "btn btn-primary pull-left #{disable_import_button(schema_name)}",
+              data: { confirm: "Import information of #{schema_name} schema? (Subscribe)" } do
+            Import
+          = link_to unlink_schema_path(@data_source.id, schema_name), method: :patch,
+              class: "btn btn-primary pull-right #{disable_unlink_button(schema_name)}",
+              data: { confirm: "Unlink #{schema_name} schema? \n(Not Delete, only unlink & stop subscribe)" } do
+            Unlink

--- a/app/views/data_sources/edit.html.haml
+++ b/app/views/data_sources/edit.html.haml
@@ -14,3 +14,6 @@
 
 .box
   = render "form"
+- if @data_source.adapter == 'redshift'
+  .box
+    = render "schema"

--- a/app/views/data_sources/edit.html.haml
+++ b/app/views/data_sources/edit.html.haml
@@ -14,6 +14,6 @@
 
 .box
   = render "form"
-- if @data_source.adapter == 'redshift'
+- if ['postgresql', 'mysql2', 'redshift'].include?(@data_source.adapter)
   .box
     = render "schema"

--- a/app/views/data_sources/edit.html.haml
+++ b/app/views/data_sources/edit.html.haml
@@ -14,6 +14,6 @@
 
 .box
   = render "form"
-- if ['postgresql', 'mysql2', 'redshift'].include?(@data_source.adapter)
+- if @data_source_schemas
   .box
     = render "schema"

--- a/app/views/settings/_data_sources.html.haml
+++ b/app/views/settings/_data_sources.html.haml
@@ -11,6 +11,7 @@
       %tr
         %th Name
         %th Description
+        %th Adapter
         %th Host
         %th Port
         %th Database Name
@@ -21,6 +22,8 @@
             = data_source.name
           %td
             = data_source.description.truncate(50)
+          %td
+            = data_source.adapter
           %td
             = data_source.host
           %td

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,8 @@ Rails.application.routes.draw do
 
   resource :setting, only: %w(show)
   resources :data_sources
+  patch "/data_sources/:id/import_schema/:schema_name" => "data_sources#import_schema", as: "import_schema"
+  patch "/data_sources/:id/unlink_schema/:schema_name" => "data_sources#unlink_schema", as: "unlink_schema"
 
   resources :masked_data, except: %w(edit update)
   resources :ignored_tables, except: %w(edit update)

--- a/spec/requests/data_sources_spec.rb
+++ b/spec/requests/data_sources_spec.rb
@@ -68,7 +68,9 @@ describe :data_sources, type: :request do
   end
 
   describe "#edit" do
-    let(:data_source) { FactoryBot.create(:data_source) }
+    let!(:data_source) { FactoryBot.create(:data_source) }
+    let!(:database_memo) { FactoryBot.create(:database_memo, name: "db", data_source: data_source) }
+    let!(:schema_memo) { FactoryBot.create(:schema_memo, database_memo: database_memo, name: "myapp") }
 
     it "shows form" do
       get edit_data_source_path(data_source)


### PR DESCRIPTION
This PR includes the following changes. 

1. Add view element for `data_sources#edit` for `PostgresSQL`, `MySQL`, `Redshift` data source
2. obsolate `search_path` dependency from `PostgreSQL`, `Redshift` data source
3. Modify Redshift Adapter ( check nullable and table count ) 

## Schema Candidates (new view element)

<img src="https://user-images.githubusercontent.com/2664198/126474301-829e6ab5-5227-43af-9ea2-f54e6e23a603.png" width=500px />

I added the `Schema Candidates` shown in this image to the data source editing page that Admin users can jump to from the setting page.
BigQuery and Presto are not supported because I have no development environment.

In this screen, schemas whose subscribe status is "subscribe" will be imported by the Import series job, and schemas whose subscribe status is "Unsubscribe" will not be imported.
The “SynchronizedDataSource" has not been modified, so it remains as it was.

To change from Unsubscribe to Subscribe, click the Import button. A SchemaMemo of the schema will be created and linked.
To change from Subscribe to Unsubscribe, click Unlink button. Then the link of the SchemaMemo will be removed (**not deleted**).

This is an view element to manage the schemas to be imported in Dmemo.

## obsolate `search_path` dependency

Until now, the schemas to be imported for PostgreSQL and Redshift were managed by the search_path setting on the DB side and IgnoreTables in the Dmemo setting.

I will remove the dependency on the search_path setting, and manage the target schema to be imported on `Schema Candidates`.