### PR TITLE
[FIX] Remove search_path from where clause of SQL in adapter

### DIFF
--- a/app/models/data_source_adapters/postgresql_adapter.rb
+++ b/app/models/data_source_adapters/postgresql_adapter.rb
@@ -12,9 +12,9 @@ module DataSourceAdapters
       source_base_class.connection.query(<<~SQL, 'SCHEMA')
         SELECT schemaname, tablename
         FROM (
-          SELECT schemaname, tablename FROM pg_tables WHERE schemaname = ANY (current_schemas(false))
+          SELECT schemaname, tablename FROM pg_tables
           UNION
-          SELECT schemaname, viewname AS tablename FROM pg_views WHERE schemaname = ANY (current_schemas(false))
+          SELECT schemaname, viewname AS tablename FROM pg_views
         ) tables
         ORDER BY schemaname, tablename;
       SQL

--- a/app/models/data_source_adapters/redshift_adapter.rb
+++ b/app/models/data_source_adapters/redshift_adapter.rb
@@ -17,13 +17,11 @@ module DataSourceAdapters
         FROM (
           SELECT table_schema, table_name, table_type
           FROM svv_tables
-          WHERE table_schema = ANY (current_schemas(false)) or table_type = 'EXTERNAL TABLE'
 
           UNION
 
           SELECT DISTINCT view_schema, view_name, 'LATE BINDING'
           FROM pg_get_late_binding_view_cols() cols(view_schema name, view_name name, col_name name, col_type varchar, col_num int)
-          WHERE view_schema = ANY (current_schemas(false))
         ) tables
         ORDER BY table_schema, table_name;
       SQL


### PR DESCRIPTION
Fix mistake in https://github.com/teamdmemo/dmemo/pull/282

Because of my carelessness, I forgot the most important fix in #282 PR.
Remove the search_path from the Redshift and PostgreSQL adapters. This will allow Dmemo to look at schemas that are not in the search_path of the connected user.
Please specify the schema in Schema Candidates as described in the previous PR.