### PR TITLE
Improve view render peformance about raw_dataset in table memo page

### DIFF
--- a/app/views/table_memos/_raw_dataset.html.haml
+++ b/app/views/table_memos/_raw_dataset.html.haml
@@ -16,8 +16,7 @@
           - table_name = @table_memo.name
           - @raw_dataset_rows.each do |row|
             %tr
-              - Array.wrap(row).each_with_index do |value, i|
-                - column = @raw_dataset_columns[i]
+              - Array.wrap(row).zip(@raw_dataset_columns).each_with_index do |(value, column), i|
                 %td
                   - if MaskedDatum.masked_column?(database_name, table_name, column.name)
                     = t("masked_text")


### PR DESCRIPTION
If the number of columns in the table is large, the table memo page display will be slow. For example, my sample table with 354 columns takes more than 8 seconds to display.
I was able to speed it up to 200ms by fixing this PR.

The cause was the block of Data that displays the raw dataset. Each time a value was displayed, the column array was accessed, which created an extra loop.

We can reduce the loop by zipping them together beforehand.